### PR TITLE
Use Telegram for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,23 @@ A Node.js application that syncs your bank transactions to Actual Budget using H
 - 🎯 Transaction mapping with detailed notes
 - 💡 Duplicate detection
 - 📦 Support for multiple budgets and accounts
-- 📱 Notifications via ntfy.sh for sync reminders
+- 📱 Notifications via ntfy.sh or Telegram for sync reminders
 
 ## How it Works
 
-Hibiscus Server implements the FinTS protocol, handling the banking communication and providing this application with a JSON endpoint for fetching transactions. Authorization with the bank usually requires user interaction (e.g. PushTAN). Because of this, the syncing process cannot be fully automatic. This application will send periodic reminders via ntfy.sh with a button triggering the sync. You can keep the notification and trigger the sync when it's convenient to confirm the authorisation prompts.
+Hibiscus Server implements the FinTS protocol, handling the banking communication and providing this application with a JSON endpoint for fetching transactions. Authorization with the bank usually requires user interaction (e.g. PushTAN). Because of this, the syncing process cannot be fully automatic. This application will send periodic reminders via ntfy.sh or a Telegram bot with a button triggering the sync. You can keep the notification and trigger the sync when it's convenient to confirm the authorisation prompts.
 
 ```mermaid
 sequenceDiagram
     participant Scheduler
-    participant ntfy
+    participant notifier as Notification Service
     participant User
     participant Server
     participant Hibiscus
     participant Actual
 
-    Scheduler->>ntfy: Send reminder notification
-    ntfy->>User: Display notification with sync button
+    Scheduler->>notifier: Send reminder notification
+    notifier->>User: Display notification with sync button
     User->>Server: Click sync button (GET /sync)
     Server->>Hibiscus: Request sync
     alt PushTAN
@@ -32,8 +32,8 @@ sequenceDiagram
       User->>Hibiscus: Authorize
     else PhotoTAN
       Hibiscus-->>Server: Request authorization (TAN entry) for PhotoTAN
-      Server->>ntfy: Request TAN entry
-      ntfy->>User: Display notification with TAN entry button
+      Server->>notifier: Request TAN entry
+      notifier->>User: Display notification with TAN entry button
       User->>Server: Click TAN entry button (GET /tan-challenge/:id)
       Server->>User: Display PhotoTAN
       User->>Server: Enter TAN from banking app
@@ -48,7 +48,7 @@ sequenceDiagram
 - Node.js
 - Hibiscus Server instance with accounts configured
 - Actual Budget instance
-- ntfy.sh topic for notifications
+- ntfy.sh topic for notifications **OR** Telegram Bot
 
 ## Installation
 
@@ -78,9 +78,12 @@ Configure the following in `config/config.json`:
 
 - `server`: Server settings
   - `publicUrl`: Public URL of your server (required for ntfy button)
-- `ntfy`: Notification settings
+- `notificationSchedule`: Cron schedule for reminders (e.g. "0 12 _/2 _ \*" for noon every 2 days)
+- `ntfy`: ntfy.sh settings
   - `topic`: Your ntfy.sh topic for notifications
-  - `schedule`: Cron schedule for reminders (e.g. "0 12 _/2 _ \*" for noon every 2 days)
+- `telegram`: Telegram settings
+  - `token`: Your bot's token
+  - `chatId`: The chat to use for notifications
 - `actual`: Global Actual Budget settings
   - `serverUrl`: Your Actual Budget server URL
   - `password`: Your Actual Budget password
@@ -94,6 +97,10 @@ Configure the following in `config/config.json`:
   - `accounts`: Array of account mappings
     - `accountId`: The Actual Budget account ID
     - `hibiscusAccountId`: The Hibiscus account ID
+
+## Telegram Setup
+
+If you want to use Telegram instead of ntfy.sh, you first need to create a bot (by sending `/newbot` to [@BotFather](https://t.me/BotFather)). Specify the `token` in the config, and omit the `chatId` for now. After starting the server, the Telegram bot should be running. If you go to your Bot in Telegram and click the *START* button, or send it any message, it will respond with the Chat ID. Stop the Server, specify the `chatId` in the config, and restart it.
 
 ## Hibiscus Setup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "ejs": "^3.1.10",
         "express": "^5.1.0",
         "express-xmlrpc": "github:philetus/express-xmlrpc",
+        "grammy": "^1.36.0",
         "node-cron": "^3.0.3",
         "node-fetch": "^3.3.2",
         "pino": "^9.6.0",
@@ -484,6 +485,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@grammyjs/types": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.20.0.tgz",
+      "integrity": "sha512-KIoikN5VTj6dcJpzMwXtouzaN3BZJ4jihBuEeXzWr25HtEfCF25V3dN11u+uNYi/9sBDvs0KCKZhyN/xFY0MBg==",
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -596,6 +603,18 @@
         "@types/http-errors": "*",
         "@types/node": "*",
         "@types/send": "*"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/accepts": {
@@ -1213,6 +1232,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -1530,6 +1558,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/grammy": {
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.36.0.tgz",
+      "integrity": "sha512-Y1HluocfdOu1ccP9VOWnsb4Ql8A4fZS13VFRArgnC5w5JaSsQjjP+C/oDZUD/e1tRDFdJ629NiT3Mnukn7lh0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@grammyjs/types": "3.20.0",
+        "abort-controller": "^3.0.0",
+        "debug": "^4.3.4",
+        "node-fetch": "^2.7.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      }
+    },
+    "node_modules/grammy/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/has-flag": {
@@ -2690,6 +2753,12 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tsx": {
       "version": "4.19.3",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
@@ -2808,6 +2877,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "ejs": "^3.1.10",
     "express": "^5.1.0",
     "express-xmlrpc": "github:philetus/express-xmlrpc",
+    "grammy": "^1.36.0",
     "node-cron": "^3.0.3",
     "node-fetch": "^3.3.2",
     "pino": "^9.6.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,15 @@
 import { loadConfig } from "@app/config";
 import { createServer } from "@app/server";
 import { logger } from "@app/utils/logger";
+import { Telegram } from "./utils/telegram";
 
 logger.info("Loading configuration");
 const config = loadConfig();
+
+if (config.telegram) {
+  // Start bot
+  Telegram.get(config);
+}
 
 const app = createServer(config);
 

--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -23,20 +23,28 @@ const budgetConfigSchema = z.object({
 
 const ntfyConfigSchema = z.object({
   topic: z.string().min(1),
-  schedule: z.string().min(1).describe("Cron syntax, e.g. '0 12 */2 * *' for noon every 2 days"),
+});
+
+const telegramConfigSchema = z.object({
+  token: z.string().min(1),
+  chatId: z.string().optional(),
 });
 
 const serverConfigSchema = z.object({
   publicUrl: z.string().url(),
 });
 
-export const configSchema = z.object({
-  server: serverConfigSchema,
-  actual: actualConfigSchema,
-  hibiscus: hibiscusConfigSchema,
-  ntfy: ntfyConfigSchema,
-  dataDir: z.string(),
-  budgets: z.array(budgetConfigSchema).min(1),
-});
+export const configSchema = z
+  .object({
+    server: serverConfigSchema,
+    actual: actualConfigSchema,
+    hibiscus: hibiscusConfigSchema,
+    notificationSchedule: z.string().min(1).describe("Cron syntax, e.g. '0 12 */2 * *' for noon every 2 days"),
+    ntfy: ntfyConfigSchema.optional(),
+    telegram: telegramConfigSchema.optional(),
+    dataDir: z.string(),
+    budgets: z.array(budgetConfigSchema).min(1),
+  })
+  .refine((data) => !!data.ntfy !== !!data.telegram, "Either ntfy or telegram config must be provided");
 
 export type Config = z.infer<typeof configSchema>;

--- a/src/utils/import-transactions.ts
+++ b/src/utils/import-transactions.ts
@@ -2,8 +2,8 @@ import api from "@actual-app/api";
 import { Config } from "@app/model/config";
 import { fetchHibiscusTransactions } from "@app/utils/hibiscus";
 import { logger } from "@app/utils/logger";
-import { sendNtfyNotification } from "@app/utils/ntfy";
 import { mapToActualTransaction } from "@app/utils/transactions";
+import { sendNotification } from "./notifications";
 
 export async function importTransactionsForAccount(config: Config, hibiscusAccountId: number) {
   try {
@@ -71,19 +71,15 @@ export async function importTransactionsForAccount(config: Config, hibiscusAccou
     }
 
     // Send notification with sync summary
-    await sendNtfyNotification(config, {
+    await sendNotification(config, {
       title: `Hibiscus Sync Complete: ${account.name}`,
       message: `Added: ${result.added.length}
 Updated: ${result.updated.length}${result.errors?.length ? `\nErrors: ${result.errors.length}` : ""}
 Balance Status: ${actualBalance === hibiscusBalance ? "✅ Balances Match" : "❌ Balances Differ"}`,
-      tags: ["bank"],
-      actions: [
-        {
-          type: "view",
-          label: "View Account",
-          url: `${config.actual.serverUrl}/accounts/${accountMapping.accountId}`,
-        },
-      ],
+      link: {
+        label: "View Account",
+        url: `${config.actual.serverUrl}/accounts/${accountMapping.accountId}`,
+      },
     });
   } finally {
     logger.info("Shutting down");

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,0 +1,27 @@
+import { Config } from "@app/model/config";
+import { sendNtfyNotification } from "./ntfy";
+import { Telegram } from "./telegram";
+
+export interface SyncNotification {
+  title: string;
+  message: string;
+  link?: { label: string; url: string };
+}
+
+export type Notifier = (config: Config, notification: SyncNotification) => Promise<void>;
+
+function getNotifier(config: Config): Notifier {
+  if (config.ntfy) {
+    return sendNtfyNotification;
+  } else if (config.telegram) {
+    const telegram = Telegram.get(config);
+    return telegram.sendNotification.bind(telegram);
+  } else {
+    throw new Error("No notification method configured");
+  }
+}
+
+export async function sendNotification(config: Config, notification: SyncNotification) {
+  const notifier: Notifier = getNotifier(config);
+  await notifier(config, notification);
+}

--- a/src/utils/scheduler.ts
+++ b/src/utils/scheduler.ts
@@ -1,24 +1,20 @@
 import { Config } from "@app/model/config";
 import { logger } from "@app/utils/logger";
-import { sendNtfyNotification } from "@app/utils/ntfy";
 import cron from "node-cron";
+import { sendNotification } from "./notifications";
 
 export function startNotificationScheduler(config: Config) {
   try {
-    logger.info(`Starting notification scheduler with schedule: ${config.ntfy.schedule}`);
+    logger.info(`Starting notification scheduler with schedule: ${config.notificationSchedule}`);
 
-    cron.schedule(config.ntfy.schedule, () => {
-      sendNtfyNotification(config, {
+    cron.schedule(config.notificationSchedule, () => {
+      sendNotification(config, {
         title: "Hibiscus Sync Reminder",
         message: "Time to sync your bank transactions",
-        tags: ["bank"],
-        actions: [
-          {
-            type: "view",
-            label: "Sync Now",
-            url: `${config.server.publicUrl}/sync`,
-          },
-        ],
+        link: {
+          label: "Sync Now",
+          url: `${config.server.publicUrl}/sync`,
+        },
       }).catch((error) => {
         logger.error("Failed to send scheduled notification: %s", error);
       });

--- a/src/utils/telegram.ts
+++ b/src/utils/telegram.ts
@@ -1,0 +1,49 @@
+import { Config } from "@app/model/config";
+import { logger } from "@app/utils/logger";
+import { Bot } from "grammy";
+import { SyncNotification } from "./notifications";
+
+export class Telegram {
+  private static _instance: Telegram;
+  private bot: Bot;
+
+  private constructor(config: Config) {
+    if (!config.telegram) {
+      throw new Error("Telegram configuration is not set");
+    }
+    this.bot = new Bot(config.telegram.token);
+    this.bot.on("message", (ctx) => {
+      ctx.reply(`Chat ID: ${ctx.chat.id}`);
+    });
+    this.bot.start();
+  }
+
+  public static get(config: Config): Telegram {
+    if (!this._instance) {
+      this._instance = new Telegram(config);
+    }
+    return this._instance;
+  }
+
+  public async sendNotification(config: Config, notification: SyncNotification) {
+    if (!config.telegram) {
+      throw new Error("Telegram configuration is not set");
+    }
+    if (!config.telegram.chatId) {
+      throw new Error("Telegram chat ID is not set");
+    }
+
+    let message = `*${notification.title}*\n\n${notification.message}`;
+    if (notification.link) {
+      message += `\n\n[${notification.link.label}](${notification.link.url})`;
+    }
+
+    try {
+      await this.bot.api.sendMessage(config.telegram.chatId, message, { parse_mode: "MarkdownV2" });
+      logger.info("Telegram notification sent successfully");
+    } catch (error) {
+      logger.error("Failed to send Telegram notification: %s", error);
+      throw new Error("Failed to send Telegram notification");
+    }
+  }
+}


### PR DESCRIPTION
I branched this off of #14, so the changelist looks a bit more excessive than it really is.

I created a generic `sendNotification()` interface in `src/utils/notifications.ts` that will look at the config and then either call the ntfy.sh notification function or the Telegram bot (which is available as a singleton). In the process I simplified the `sendNtfyNotification()` interface a bit (always `bank` tag, up to one view action).

Since the `notificationSchedule` config is not only applicable to ntfy.sh but also to Telegram, I moved it to the top level config -- so that's a breaking change, I guess. If you prefer, we could move it back to the `ntfy` config (or maybe even have separate schedules for ntfy.sh and Telegram?).

I've designed it so using ntfy.sh and Telegram is exclusive. We could also allow using both at the same time with minimal effort if you prefer, although I'm not sure if there's a usecase for that.

Closes #17,